### PR TITLE
Add names to start page and individual tasks

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,12 @@
     </head>
     <body>
         <h1 class="heading">Teamprojekt Roboarena</h1>
+        <hr><hr>
         <h2 class="heading">Team 2</h2>
+        <h3 class="heading">Katja Grammel (Discord: katjagrammel, GitHub: Katja102)</h3>
+        <h3 class="heading">Walid Abdulhamid (Discord: _trustii, GitHub: also-walid)</h3>
+        <h3 class="heading">Nico Loroff (Discord: insanix, GitHub:NiLo911)</h3>
+        <h3 class="heading">Sarah Herty (Discord: ._.sarahh, GitHub: SarahH899)</h3>
         <hr><hr>
         <h2><a href="sprint1.html">1. Sprint (11.4. - 25.4.)</a></h2>
     </body>

--- a/docs/sprint1.html
+++ b/docs/sprint1.html
@@ -20,11 +20,12 @@
         <h1>1. Sprint (11.4. - 25.4.):</h1>
         <h3>Die ersten Schritte, bevor unser Projekt richtig starten kann:</h3>
         <ul>
-            <li>Wir wollen mit Python und pyGame arbeiten, also haben wir erstmal alles heruntergeladen und eingerichtet.</li>
-            <li>Wir haben ein Github Repository für unser Projekt erstellt.<br>
+            <li>Wir wollen mit Python und pyGame arbeiten, also haben wir erstmal alles heruntergeladen und eingerichtet.
+                 (jeder für sich allein)</li>
+            <li>Wir haben ein Github Repository für unser Projekt erstellt. (Katja)<br>
                 <img src = "Sprint_1/screenshots/Repo_erstellen.webp"><br>
                 <a href="https://github.com/Katja102/Roboarena"> hier gehts zum Repository</a> </li>
-            <li>Und eine Github Action dafür eingerichtet, die für jeden neuen Pull Request einen Flake8 Test durchführt.<br>
+            <li>Und eine Github Action dafür eingerichtet, die für jeden neuen Pull Request einen Flake8 Test durchführt. (Walid)<br>
                 <img src = "Sprint_1/screenshots/Screenshot_Flake8_PR.png"><br>
                 <img src = "Sprint_1/screenshots/Screenshot_Flake8.png"> <br>
                 Um zu prüfen, ob der Test auch funktioniert haben wir in einem Testbranch eine Datei erstellt, die einige Probleme enthält:<br>
@@ -32,25 +33,26 @@
                 Und tatsächlich hat unser Test die Probleme erkannt!<br>
                 <img src = "Sprint_1/screenshots/Screenshot_test_error.png"><br>
             </li>
-            <li>Zuletzt haben wir diese Seite erstellt, in der wir über unsere Sprints berichten.</li>
+            <li>Zuletzt haben wir diese Seite erstellt, in der wir über unsere Sprints berichten. (Sarah)</li>
         </ul>
         <br><br>
         <h3>Nachdem alles vorbereitet war, haben wir unser erstes kleines Programm mit pygame erstellt:</h3>
         <p>
             Gestartet haben wir mit einem Spiel, bei dem man ein Viereck mit Hilfe der Pfeiltasten der Tastatur
             durch ein Labyrinth bewegen muss. Ziel des Spiels ist es, den Zielbereich zu erreichen.
-            Trifft man die Wände, verliert man ein Leben, wobei man mit 3 Leben startet.<br>
+            Trifft man die Wände, verliert man ein Leben, wobei man mit 3 Leben startet. (Walid)<br>
             <img src = "Sprint_1/screenshots/Spiel_basic.png">
             <br>
             Dann hat jedes der anderen Teammitglieder das Spiel Stück für Stück erweitert.
             Es folgte...<br>
-            ... ein 2. Level,<br>
+            ... ein 2. Level, (Katja)<br>
             <img src = "Sprint_1/screenshots/Spiel_level2.png">
             <br>
-            ... ein Slowdown-Button, der das Viereck kurzzeitig verlangsamt<br>
+            ... ein Slowdown-Button, der das Viereck kurzzeitig verlangsamt (Sarah)<br>
             <img src = "Sprint_1/screenshots/Spiel_slow.png">
             <br>
-            ... und eine sich bewegende Wand, die sonst aber wie alle anderen Wände funktioniert.<br>
+            ... und eine sich bewegende Wand, die sonst aber wie alle anderen Wände funktioniert.
+             (Nico)<br>
             <img src = "Sprint_1/screenshots/Spiel_obstacle.png">
             <br>
             Die Änderungen wurden alle auf separaten branches erstellt und nach Pull Requests und Reviews in den main branch gemerged.


### PR DESCRIPTION
At the start page (index.html) of our GitHub io-page, I added the names of all team members as well as their discord and GitHub user names.
At the documentation of our first sprint (sprint1.html), I added our names to the tasks we did, so you can see who did the exercise.