### PR TITLE
Update flake8.yml

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -21,4 +21,4 @@ jobs:
         pip install flake8
 
     - name: Run flake8
-      run: flake8 .
+      run: flake8 src/


### PR DESCRIPTION
Limit flake8 linting to the `src/` directory instead of the entire project, to avoid unnecessary errors from external files