### PR TITLE
fix for boundary error from adaptiv window size

### DIFF
--- a/src/robot.py
+++ b/src/robot.py
@@ -1,10 +1,5 @@
 import pygame
 import math
-import config
-
-# Boundaries for movement
-BOUNDS_X = [0, config.WIDTH]
-BOUNDS_Y = [0, config.HEIGHT]
 
 # Maximum acceleration values
 a_max = 1
@@ -62,10 +57,6 @@ class Robot:
 
         # Check for collisions
         self.robot_collision(robots)
-
-        # Keep the robot within the screen boundaries
-        self.x = max(BOUNDS_X[0], min(self.x, BOUNDS_X[1] - self.r))
-        self.y = max(BOUNDS_Y[0], min(self.y, BOUNDS_Y[1] - self.r))
 
     def update_enemy(self, goal, robots):
         # Move towards a goal position


### PR DESCRIPTION
the boundaries in robot.py were dependent on width in config. since the window is reliant on the screen size width in config is deleted. With this commit the game does work, but there are no boundaries for robots. These can be coded in with the effects of the map.