### PR TITLE
Added map effects

### DIFF
--- a/src/arena.py
+++ b/src/arena.py
@@ -8,7 +8,7 @@ class Arena:
         screen: pygame.Surface,
         rows: int,
         columns: int,
-        textures: dict[str, pygame.Surface]
+        textures: dict[str, pygame.Surface],
     ):
         self.screen = screen  # current game screen
         self.rows = rows  # number of rows
@@ -69,3 +69,24 @@ class Arena:
     def draw_map(self) -> None:
         if self.map_picture:
             self.screen.blit(self.map_picture, (0, 0))
+
+    def wall_tiles(self) -> list[tuple[int, int]]:
+        wall_tiles = []
+        for i in range(0, config.ROWS):
+            for j in range(0, config.COLUMNS):
+                if self.grid[i][j] == "wall":
+                    wall_tiles.append([j, i])
+        return wall_tiles
+
+    def walls(self) -> list[pygame.Rect]:
+        walls: list[pygame.Rect] = []
+        wall_tiles = self.wall_tiles()
+        for wall_tile in wall_tiles:
+            wall = pygame.Rect(
+                wall_tile[0] * config.TILE_SIZE,
+                wall_tile[1] * config.TILE_SIZE,
+                config.TILE_SIZE,
+                config.TILE_SIZE,
+            )
+            walls.append(wall)
+        return walls

--- a/src/main.py
+++ b/src/main.py
@@ -30,14 +30,15 @@ print(f"Monitor: {max_width}x{max_height}")
 print(f"Fenster: {window_width}x{window_height}")
 print(f"TILE_SIZE: {config.TILE_SIZE}")
 
-# Load map and arena
+# Load map and arena and walls
 arena: Arena = Arena(screen, config.ROWS, config.COLUMNS, config.TEXTURES)
 arena.create_map(map.get_map("test-level.txt"))
+walls = arena.walls()
 
 player: Robot = Robot(screen, 500, 500, 20, 180, (255, 255, 255), 1, 1)
 enemy1: Robot = Robot(screen, 800, 300, 30, 0, (0, 100, 190), 1, 1)
 enemy2: Robot = Robot(screen, 300, 600, 40, 50, (255, 50, 120), 1, 1)
-enemy3: Robot = Robot(screen, 1200, 600, 40, 50, (0, 250, 0), 1, 1)
+enemy3: Robot = Robot(screen, 1300, 600, 40, 50, (0, 250, 0), 1, 1)
 
 robots: list[Robot] = [player, enemy1, enemy2, enemy3]
 
@@ -57,13 +58,13 @@ while running:
     screen.fill((220, 220, 220))  # light gray background
     arena.draw_map()
     ticks = pygame.time.get_ticks()
-    player.update_player(robots)
+    player.update_player(robots, arena, walls)
     if ticks > circle_tick:
         circle_tick += 50
         angle = (angle + 3) % 360
-    enemy1.move_circle((800, 300), 50, angle, robots)
-    enemy2.update_enemy(player, robots)
-    enemy3.update_enemy(player, robots)
+    enemy1.move_circle((800, 300), 50, angle, robots, arena)
+    enemy2.update_enemy(player, robots, arena, walls)
+    enemy3.update_enemy(player, robots, arena, walls)
     pygame.display.flip()
     clock.tick(60)
 

--- a/src/robot.py
+++ b/src/robot.py
@@ -3,6 +3,10 @@ import config
 import math
 from arena import Arena
 
+# Constants
+ice_acceleration: float = 2
+sand_accerleration: float = 1 / 2
+
 
 class Robot:
     def __init__(
@@ -172,11 +176,11 @@ class Robot:
     def map_effects(self, arena: Arena, robots: list["Robot"]) -> None:
         touched_textures = self.touched_textures(arena)
         if "ice" in touched_textures:
-            self.v = self.speed * 2
-            self.v_alpha = self.speed_alpha * 2
+            self.v = self.speed * ice_acceleration
+            self.v_alpha = self.speed_alpha * ice_acceleration
         elif "sand" in touched_textures:
-            self.v = self.speed / 2
-            self.v_alpha = self.speed_alpha / 2
+            self.v = self.speed * sand_accerleration
+            self.v_alpha = self.speed_alpha * sand_accerleration
         elif "wall" in touched_textures:
             pass
         else:


### PR DESCRIPTION
I added the map effects (except lava which will be added after spawn logic is resolved). Ice, Sand, Lava and Bush are dealt with in map_effects in robot.py. Walls are dealt with seperately to only get the list of wall tiles once. I did not include the changes in move_circle, since it is not a useful function for the later game.

resolves #35