### PR TITLE
fixed wall collision and varied movement along walls

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -82,7 +82,7 @@ while running:
         angle = (angle + 3) % 360
     for robot in robots:
         if robot == enemy1:
-            enemy1.move_circle(spawn_positions[1], 50, angle, robots, game_map)
+            enemy1.update_enemy(enemy2, robots, game_map, walls)
         if robot == enemy2:
             enemy2.update_enemy(player, robots, game_map, walls)
         if robot == enemy3:


### PR DESCRIPTION
I altered robot_collision to avoid being pushed into walls and added to move_if_no_walls to avoid robots not moving at all if goal is behind wall. The robots should be able to reach the desired goal by driving along a wall that is in the way.
I also made enemy1 to follow enemy2, instead of moving in a circle, since it is more along our goal.

resolves #53 
