### PR TITLE
added dynamic camera; cam stays inside map + adjusted objects to support the camera

### DIFF
--- a/src/bullet.py
+++ b/src/bullet.py
@@ -5,9 +5,6 @@ from map import Map
 from camera import Camera
 
 
-velocity = 10
-
-
 class Bullet:
     def __init__(
         self,
@@ -17,6 +14,7 @@ class Bullet:
         radius: int,
         color: tuple[int, int, int],
         shooter,  # :Robot
+        velocity: float,
     ):
         self.x = x  # x-coordiante of center
         self.y = y  # y-coordiante of center

--- a/src/camera.py
+++ b/src/camera.py
@@ -2,20 +2,93 @@ import pygame
 
 
 class Camera:
-    def __init__(self, camera_surface_width: int, camera_surface_height: int):
+    def __init__(
+        self,
+        camera_surface_width: int,
+        camera_surface_height: int,
+        map_pixel_width: int,
+        map_pixel_height: int,
+    ):
+        self.zoom: float = 1.3  # Current zoom level
         self.camera_surface_width = camera_surface_width
         self.camera_surface_height = camera_surface_height
+        self.map_pixel_width = map_pixel_width  # Total map width in pixels
+        self.map_pixel_height = map_pixel_height  # Total map height in pixels
         self.offset_x = 0
         self.offset_y = 0
+        self.center_x = 0  # Camera center X in world coords
+        self.center_y = 0  # Camera center Y in world coords
         self.surface = pygame.Surface(
             (self.camera_surface_width, self.camera_surface_height)
         )
 
-    def follow(self, target_x: int, target_y: int):
-        """Centers the camera on the target position (the player)"""
-        self.offset_x = target_x - self.camera_surface_width // 2
-        self.offset_y = target_y - self.camera_surface_height // 2
+    def follow_dynamic_center(self, robots: list, player):
+        """
+        follow the center between all robots and the player
+        adjust zoom based on average distance to enemies
+        hold camera inside map boundaries
+        """
+        all_bots = robots + [player]
+
+        if not all_bots:
+            cx, cy = player.x, player.y
+            avg_distance = 0
+        else:
+            # Average position of all bots
+            sum_x = sum(bot.x for bot in all_bots)
+            sum_y = sum(bot.y for bot in all_bots)
+            n = len(all_bots)
+            cx = sum_x / n
+            cy = sum_y / n
+
+            # Average distance from enemies to player
+            distances = [
+                ((bot.x - player.x) ** 2 + (bot.y - player.y) ** 2) ** 0.5
+                for bot in robots
+            ]
+            avg_distance = sum(distances) / len(distances) if distances else 0
+
+        # Set initial center directly
+        if self.center_x == 0 and self.center_y == 0:
+            self.center_x = cx
+            self.center_y = cy
+
+        # Smoothly follow the target center
+        self.center_x += (cx - self.center_x) * 0.1
+        self.center_y += (cy - self.center_y) * 0.1
+
+        # Compute Offset based on center + zoom
+        half_width = self.camera_surface_width / (2 * self.zoom)
+        half_height = self.camera_surface_height / (2 * self.zoom)
+        self.offset_x = int(self.center_x - half_width)
+        self.offset_y = int(self.center_y - half_height)
+
+        # Dynamic zoom based on distances
+        avg_distance = max(20, min(avg_distance, 800))
+
+        # Zoom range
+        zoom_near = 1.5
+        zoom_far = 0.6
+
+        # Zoom interpolation [0, 1]
+        norm_dist = (avg_distance - 100) / 700
+        norm_dist = max(0.0, min(norm_dist, 1.0))
+        target_zoom = zoom_near - norm_dist * (zoom_near - zoom_far)
+        self.zoom += (target_zoom - self.zoom) * 0.1
+
+        # Hold Camera inside the map
+        max_offset_x = self.map_pixel_width - (self.camera_surface_width / self.zoom)
+        max_offset_y = self.map_pixel_height - (self.camera_surface_height / self.zoom)
+        self.offset_x = max(0, min(self.offset_x, int(max_offset_x)))
+        self.offset_y = max(0, min(self.offset_y, int(max_offset_y)))
 
     def apply(self, x: int, y: int) -> tuple[int, int]:
         """Converts world coordinates to screen coordinates"""
-        return x - self.offset_x, y - self.offset_y
+        screen_x = (x - self.offset_x) * self.zoom
+        screen_y = (y - self.offset_y) * self.zoom
+        return int(screen_x), int(screen_y)
+
+    def set_zoom_to(self, value: float):
+        # Set zoom level directly limited between 0.8 and 3.0.
+
+        self.zoom = max(0.8, min(value, 3.0))

--- a/src/config.py
+++ b/src/config.py
@@ -23,6 +23,5 @@ ICONS: dict[str, pygame.Surface] = {
 TILE_SIZE: int = 0  # will be assigned during runtime in main.py
 COLUMNS: int = 48  # number of tile columns (horizontal)
 ROWS: int = 27  # number of tile rows (vertical)
-ZOOM: float = 1.3  # scaling factor applied to all tiles and objects
 ROBOT_RENDER_SIZE = 64  # always 64x64 px
 SHOW_STATS: bool = True  # Toggle to show or hide HP and Power numbers

--- a/src/main.py
+++ b/src/main.py
@@ -22,7 +22,7 @@ max_height: int = info.current_h
 base_tile_size = min(max_width // config.COLUMNS, max_height // config.ROWS)
 
 # Apply zoom
-config.TILE_SIZE = int(base_tile_size * config.ZOOM)
+config.TILE_SIZE = int(base_tile_size * 2)
 
 # Create window (not fullscreen)
 window_width: int = base_tile_size * config.COLUMNS
@@ -402,13 +402,17 @@ def game_loop(map_file: str | None = None):
     if map_file is None:
         map_file = "test-level.txt"
 
+    # Map setup
+    game_map = Map(map_file)
+    map_data = game_map.get_map_data()
+    map_width_px = len(map_data[0]) * config.TILE_SIZE
+    map_height_px = len(map_data) * config.TILE_SIZE
+
     # Camera setup
     camera_width = window_width
     camera_height = window_height
-    camera = Camera(camera_width, camera_height)
+    camera = Camera(camera_width, camera_height, map_width_px, map_height_px)
 
-    # Map setup
-    game_map = Map(map_file)
     map_renderer = MapRenderer(camera.surface, config.TEXTURES)
     map_renderer.draw_map_picture(game_map.get_map_data())
     walls: list[pygame.Rect] = game_map.walls()
@@ -423,7 +427,7 @@ def game_loop(map_file: str | None = None):
         robot_size,
         0,
         (255, 255, 255),
-        2,
+        2 * camera.zoom,
         3,
         True,
         "Tank",
@@ -434,7 +438,7 @@ def game_loop(map_file: str | None = None):
         robot_size,
         0,
         (0, 100, 190),
-        2,
+        2 * camera.zoom,
         3,
         False,
         "Spider",
@@ -445,7 +449,7 @@ def game_loop(map_file: str | None = None):
         robot_size,
         50,
         (255, 50, 120),
-        2,
+        2 * camera.zoom,
         3,
         False,
         "Spider",
@@ -456,7 +460,7 @@ def game_loop(map_file: str | None = None):
         robot_size,
         50,
         (0, 250, 0),
-        2,
+        2 * camera.zoom,
         3,
         False,
         "Tank",
@@ -474,7 +478,7 @@ def game_loop(map_file: str | None = None):
     # run game
     while running:
         dt = clock.tick(60) / 300  # animation speed
-        camera.follow(player.x, player.y)
+        camera.follow_dynamic_center(robots, player)
 
         # Event handling
         for event in pygame.event.get():
@@ -506,12 +510,17 @@ def game_loop(map_file: str | None = None):
                 goals.append(robot.get_robot_with_distance_prob(game_map, robots))
         for robot in robots:
             if robot is player:  # player
-                player.update_player(robots, game_map, walls, bullets)
+                player.update_player(robots, game_map, walls, bullets, camera)
                 if player.hp <= 0:
                     gameover()
             else:  # enemies
                 robot.update_enemy(
-                    goals[robots.index(robot) - 1], robots, game_map, walls, bullets
+                    goals[robots.index(robot) - 1],
+                    robots,
+                    game_map,
+                    walls,
+                    bullets,
+                    camera,
                 )
                 if robot.hp <= 0:
                     robots.remove(robot)
@@ -525,9 +534,9 @@ def game_loop(map_file: str | None = None):
             if robot.in_bush:
                 for i, j in robot.bush_tiles:
                     texture = config.TEXTURES["bush"]
-                    tile = pygame.transform.scale(
-                        texture, (config.TILE_SIZE, config.TILE_SIZE)
-                    )
+                    tile_size = int(config.TILE_SIZE * camera.zoom)
+                    tile = pygame.transform.scale(texture, (tile_size, tile_size))
+
                     camera.surface.blit(
                         tile, camera.apply(i * config.TILE_SIZE, j * config.TILE_SIZE)
                     )

--- a/src/map_renderer.py
+++ b/src/map_renderer.py
@@ -34,5 +34,17 @@ class MapRenderer:
     def draw_map(self, camera: Camera) -> None:
         """Shows the visible part of the map through the camera."""
         if self.map_picture:
-            offset = camera.apply(0, 0)
-            self.camera_surface.blit(self.map_picture, offset)
+            # Move map based on camera offset and scale
+            offset_x = int(-camera.offset_x * camera.zoom)
+            offset_y = int(-camera.offset_y * camera.zoom)
+
+            # Scale map according to zoom level
+            scaled_map = pygame.transform.scale(
+                self.map_picture,
+                (
+                    int(self.map_picture.get_width() * camera.zoom),
+                    int(self.map_picture.get_height() * camera.zoom),
+                ),
+            )
+            # Draw the zoomed map
+            self.camera_surface.blit(scaled_map, (offset_x, offset_y))

--- a/src/robot.py
+++ b/src/robot.py
@@ -5,6 +5,7 @@ import math
 import random
 from map import Map
 from sounds import Sounds
+from camera import Camera
 
 # Constants
 ice_acceleration: float = 2
@@ -34,10 +35,10 @@ class Robot:
         self.hitbox_radius = hitbox_radius  # radius of the hitbox
         self.alpha = direction % 360  # direction of the robot in degree
         self.color = color  # color of the robot
-        self.v = speed * config.ZOOM  # current acceleration for moving
-        self.v_alpha = speed_alpha * config.ZOOM  # current acceleration for turning
-        self.speed = speed * config.ZOOM  # speed for moving
-        self.speed_alpha = speed_alpha * config.ZOOM  # speed for turning
+        self.v = speed * 2  # current acceleration for moving
+        self.v_alpha = speed_alpha * 2  # current acceleration for turning
+        self.speed = speed * 2  # speed for moving
+        self.speed_alpha = speed_alpha * 2  # speed for turning
         self.hp = 100  # current livepoints of the robot
         self.last_shot_time = 0  # time of last shot
         self.shot_break_duration = 2000  # min duration of break between shots
@@ -66,6 +67,7 @@ class Robot:
         game_map: Map,
         walls: list[pygame.Rect],
         bullets: list[Bullet],
+        camera: Camera,
     ) -> None:
         # Check for effect
         self.map_effects(game_map, robots)
@@ -104,7 +106,7 @@ class Robot:
 
         # check, if user used a key for shooting
         if keys[pygame.K_s]:
-            self.shoot(bullets)
+            self.shoot(bullets, camera)
 
     # Lets a robot follow another robot
     def update_enemy(
@@ -114,6 +116,7 @@ class Robot:
         game_map: Map,
         walls: list[pygame.Rect],
         bullets: list[Bullet],
+        camera: Camera,
     ) -> None:
         # Check for effect
         self.map_effects(game_map, robots)
@@ -155,7 +158,7 @@ class Robot:
         # shoot if angle to goal is under 10°
         angle_diff = abs(abs(angle_to_goal - 180) - self.alpha) % 360
         if (angle_diff <= 10) or (angle_diff >= 350):
-            self.shoot(bullets)
+            self.shoot(bullets, camera)
 
         # avoid being in range of other robots
         self.move_if_in_range(robots, walls, game_map)
@@ -365,7 +368,7 @@ class Robot:
                     self.x = xnew
                     self.y = ynew
 
-    def shoot(self, bullets: list[Bullet]):
+    def shoot(self, bullets: list[Bullet], camera: Camera):
         current_time = pygame.time.get_ticks()
         # make sure there is a break between the shots
         if current_time - self.last_shot_time < self.shot_break_duration:
@@ -383,9 +386,10 @@ class Robot:
             int(start_x),
             int(start_y),
             self.alpha,
-            7,
+            7 * camera.zoom,
             (0, 0, 0),
-            shooter=self,
+            self,
+            20 * camera.zoom,
         )  # create bullet
         self.last_shot_time = current_time  # update time of last shot
         self.power -= 20  # update power

--- a/src/robot_renderer.py
+++ b/src/robot_renderer.py
@@ -103,9 +103,9 @@ class RobotRenderer:
             # Get current animation frame
             frame = self.animations[robot.robot_type][self.frame_indices.get(robot, 0)]
 
-            # Scale the image to the robot's hitbox size
+            scaled_size = int(robot.hitbox_radius * camera.zoom)
             scaled_image = pygame.transform.smoothscale(
-                frame, (robot.hitbox_radius, robot.hitbox_radius)
+                frame, (scaled_size, scaled_size)
             )
 
             # Rotate after scaling
@@ -151,8 +151,8 @@ class RobotRenderer:
         power_height = robot.hitbox_radius * 0.15
         power_width = robot.hitbox_radius
         power_x, power_y = camera.apply(
-            robot.x - (0.48 * robot.hitbox_radius),
-            robot.y + (0.8 * robot.hitbox_radius),
+            robot.x - 46 / camera.zoom,
+            robot.y + (robot.hitbox_radius * 0.5 * (-camera.zoom)) + 130,
         )
         fill_width = power_width * (robot.power / 100)
 


### PR DESCRIPTION
I added a dynamic camera system that follows the average position of the player and all bots. It uses functions like follow_dynamic_center(...) and set_zoom_to(...) to smoothly move toward center_x and center_y using interpolation. The zoom level changes based on the average distance between the player and enemies: it zooms out when they’re far and zooms in when they’re close.

I also updated all other classes to support camera.zoom like robot size, velocity, bullet speed, radius, the bars... Additionally the camera always stays within the map boundaries.