### PR TITLE
Small fixes

### DIFF
--- a/src/button.py
+++ b/src/button.py
@@ -2,7 +2,17 @@ import pygame
 
 
 class Button:
-    def __init__(self, rect, text, font, bg_color, text_color, hover_color=None):
+    def __init__(
+        self,
+        rect,
+        text,
+        font,
+        bg_color,
+        text_color,
+        hover_color=None,
+        selected=False,
+        selected_color=None,
+    ):
         """
         rect: pygame.Rect oder Tupel (x, y, width, height)
         text: Button-Beschriftung
@@ -17,13 +27,17 @@ class Button:
         self.bg_color = bg_color
         self.text_color = text_color
         self.hover_color = hover_color if hover_color else bg_color
+        self.selected = selected
+        self.selected_color = selected_color if selected_color else bg_color
 
         self.text_surface = self.font.render(self.text, True, self.text_color)
         self.text_rect = self.text_surface.get_rect(center=self.rect.center)
 
     def draw(self, screen):
         mouse_pos = pygame.mouse.get_pos()
-        if self.rect.collidepoint(mouse_pos):
+        if self.selected:
+            color = self.selected_color
+        elif self.rect.collidepoint(mouse_pos):
             color = self.hover_color
         else:
             color = self.bg_color

--- a/src/main.py
+++ b/src/main.py
@@ -532,19 +532,19 @@ def options():
 
             if easy_button.is_clicked(event):
                 difficulty = "easy"
-                return options()
+                return options()  # noqa: F821
             if medium_button.is_clicked(event):
                 difficulty = "medium"
-                return options()
+                return options()  # noqa: F821
             if hard_button.is_clicked(event):
                 difficulty = "hard"
-                return options()
+                return options()  # noqa: F821
             if survival1_button.is_clicked(event):
                 difficulty = "survival1"
-                return options()
+                return options()  # noqa: F821
             if survival2_button.is_clicked(event):
                 difficulty = "survival2"
-                return options()
+                return options()  # noqa: F821
             if back_button.is_clicked(event):
                 return
 

--- a/src/main.py
+++ b/src/main.py
@@ -994,8 +994,27 @@ def game_loop(map_file: str | None = None):
         # Robots appearing for survival mode
         if difficulty == "survival1":  # more
             if ticks - start_tick > robot_tick:
+                robot_tick += robot_tick_increaser
                 if robot_tick > 3500:
-                    robot_tick += robot_tick_increaser
+                    robot_tick_increaser -= 500
+                robots.append(
+                    Robot(
+                        camera.surface,
+                        -1000,
+                        -1000,
+                        player.hitbox_radius,
+                        float(random.randint(0, 359)),
+                        (255, 255, 255),
+                        2,
+                        2,
+                        False,
+                        random.choice(("Spider", "Tank")),
+                    )
+                )
+                robots[len(robots) - 1].get_spawn_position(game_map, robots)
+            if len(robots) < 2:
+                robot_tick = ticks - start_tick + robot_tick_increaser
+                if robot_tick > 3500:
                     robot_tick_increaser -= 500
                 robots.append(
                     Robot(
@@ -1078,12 +1097,10 @@ def gameover(camera, map_renderer, robot_renderer, robots, player, score=-1, kil
                 highscore = score
             if highestkills < kills:
                 highestkills = kills
-            draw_text(screen, f"Highscore: {highscore}s", 0, 400, 100, center=True)
-            draw_text(screen, f"Score: {score}s", 0, 500, 100, center=True)
-            draw_text(
-                screen, f"Highest Kills: {highestkills}", 0, 600, 100, center=True
-            )
-            draw_text(screen, f"Kills: {kills}", 0, 700, 100, center=True)
+            draw_text(screen, f"Highscore: {highscore}s", 0, 330, 70, center=True)
+            draw_text(screen, f"Score: {score}s", 0, 400, 70, center=True)
+            draw_text(screen, f"Highest Kills: {highestkills}", 0, 470, 70, center=True)
+            draw_text(screen, f"Kills: {kills}", 0, 540, 70, center=True)
 
         for event in pygame.event.get():
             if event.type == pygame.QUIT:

--- a/src/main.py
+++ b/src/main.py
@@ -657,7 +657,7 @@ def level_selection():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
-        selected=current_map == "test-level.txt" and random_map == False,
+        selected=current_map == "test-level.txt" and not random_map,
         selected_color=(0, 100, 150),
     )
 
@@ -668,7 +668,7 @@ def level_selection():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
-        selected=current_map == "test-level2.txt" and random_map == False,
+        selected=current_map == "test-level2.txt" and not random_map,
         selected_color=(0, 100, 150),
     )
 
@@ -679,7 +679,7 @@ def level_selection():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
-        selected=current_map == "lavariver.txt" and random_map == False,
+        selected=current_map == "lavariver.txt" and not random_map,
         selected_color=(0, 100, 150),
     )
 
@@ -690,7 +690,7 @@ def level_selection():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
-        selected=current_map == "fourelements.txt" and random_map == False,
+        selected=current_map == "fourelements.txt" and not random_map,
         selected_color=(0, 100, 150),
     )
 
@@ -701,7 +701,7 @@ def level_selection():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
-        selected=random_map == True,
+        selected=random_map,
         selected_color=(0, 100, 150),
     )
 

--- a/src/main.py
+++ b/src/main.py
@@ -1020,7 +1020,7 @@ def game_loop(map_file: str | None = None):
 
         # Robots appearing for survival mode
         if difficulty == "survival1":  # more
-            if ticks - start_tick > robot_tick:
+            if ticks - start_tick > robot_tick:  # time for new robot
                 robot_tick += robot_tick_increaser
                 if robot_tick_increaser > 3500:
                     robot_tick_increaser -= 500
@@ -1038,7 +1038,7 @@ def game_loop(map_file: str | None = None):
                     )
                 )
                 robots[len(robots) - 1].get_spawn_position(game_map, robots)
-            if len(robots) < 2:
+            if len(robots) < 2:  # currently no alive enemy
                 robot_tick = ticks - start_tick + robot_tick_increaser
                 if robot_tick_increaser > 3500:
                     robot_tick_increaser -= 500

--- a/src/main.py
+++ b/src/main.py
@@ -1022,7 +1022,7 @@ def game_loop(map_file: str | None = None):
         if difficulty == "survival1":  # more
             if ticks - start_tick > robot_tick:
                 robot_tick += robot_tick_increaser
-                if robot_tick > 3500:
+                if robot_tick_increaser > 3500:
                     robot_tick_increaser -= 500
                 robots.append(
                     Robot(
@@ -1040,7 +1040,7 @@ def game_loop(map_file: str | None = None):
                 robots[len(robots) - 1].get_spawn_position(game_map, robots)
             if len(robots) < 2:
                 robot_tick = ticks - start_tick + robot_tick_increaser
-                if robot_tick > 3500:
+                if robot_tick_increaser > 3500:
                     robot_tick_increaser -= 500
                 robots.append(
                     Robot(

--- a/src/main.py
+++ b/src/main.py
@@ -451,6 +451,8 @@ def options():
     clock = pygame.time.Clock()
     font = pygame.font.SysFont(None, 40)
 
+    global difficulty
+
     easy_button = Button(
         rect=(screen.get_width() // 2 - 350, 300, 200, 50),
         text="Easy",
@@ -458,6 +460,8 @@ def options():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
+        selected=difficulty == "easy",
+        selected_color=(0, 100, 150),
     )
 
     medium_button = Button(
@@ -467,6 +471,8 @@ def options():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
+        selected=difficulty == "medium",
+        selected_color=(0, 100, 150),
     )
 
     hard_button = Button(
@@ -476,6 +482,8 @@ def options():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
+        selected=difficulty == "hard",
+        selected_color=(0, 100, 150),
     )
 
     survival1_button = Button(
@@ -485,6 +493,8 @@ def options():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
+        selected=difficulty == "survival1",
+        selected_color=(0, 100, 150),
     )
 
     survival2_button = Button(
@@ -494,6 +504,8 @@ def options():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
+        selected=difficulty == "survival2",
+        selected_color=(0, 100, 150),
     )
 
     back_button = Button(
@@ -513,8 +525,6 @@ def options():
 
         draw_text(screen, "Difficulty", 0, 250, 50, center=True)
 
-        global difficulty
-
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 pygame.quit()
@@ -522,14 +532,19 @@ def options():
 
             if easy_button.is_clicked(event):
                 difficulty = "easy"
+                return options()
             if medium_button.is_clicked(event):
                 difficulty = "medium"
+                return options()
             if hard_button.is_clicked(event):
                 difficulty = "hard"
+                return options()
             if survival1_button.is_clicked(event):
                 difficulty = "survival1"
+                return options()
             if survival2_button.is_clicked(event):
                 difficulty = "survival2"
+                return options()
             if back_button.is_clicked(event):
                 return
 
@@ -565,6 +580,8 @@ def class_selection():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
+        selected=type == "Tank",
+        selected_color=(0, 100, 150),
     )
 
     spider_button = Button(
@@ -574,6 +591,8 @@ def class_selection():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
+        selected=type == "Spider",
+        selected_color=(0, 100, 150),
     )
 
     back_button = Button(
@@ -599,8 +618,10 @@ def class_selection():
                 game_loop()
             if tank_button.is_clicked(event):
                 type = "Tank"
+                return class_selection()
             if spider_button.is_clicked(event):
                 type = "Spider"
+                return class_selection()
             if back_button.is_clicked(event):
                 return
 
@@ -619,7 +640,6 @@ def level_selection():
     global random_map
     global current_map
     global seed
-    random_map = False  # reset this variable each time level selection is called
 
     start_button = Button(
         rect=(screen.get_width() // 2 - 100, 510, 200, 50),
@@ -637,6 +657,8 @@ def level_selection():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
+        selected=current_map == "test-level.txt" and random_map == False,
+        selected_color=(0, 100, 150),
     )
 
     level2_button = Button(
@@ -646,6 +668,8 @@ def level_selection():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
+        selected=current_map == "test-level2.txt" and random_map == False,
+        selected_color=(0, 100, 150),
     )
 
     level3_button = Button(
@@ -655,6 +679,8 @@ def level_selection():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
+        selected=current_map == "lavariver.txt" and random_map == False,
+        selected_color=(0, 100, 150),
     )
 
     level4_button = Button(
@@ -664,6 +690,8 @@ def level_selection():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
+        selected=current_map == "fourelements.txt" and random_map == False,
+        selected_color=(0, 100, 150),
     )
 
     random_button = Button(
@@ -673,6 +701,8 @@ def level_selection():
         bg_color=(20, 130, 200),
         text_color=(255, 255, 255),
         hover_color=(40, 160, 255),
+        selected=random_map == True,
+        selected_color=(0, 100, 150),
     )
 
     back_button = Button(
@@ -698,15 +728,24 @@ def level_selection():
                 game_loop(current_map)
             if level1_button.is_clicked(event):
                 current_map = "test-level.txt"
+                random_map = False
+                return level_selection()
             if level2_button.is_clicked(event):
                 current_map = "test-level2.txt"
+                random_map = False
+                return level_selection()
             if level3_button.is_clicked(event):
                 current_map = "lavariver.txt"
+                random_map = False
+                return level_selection()
             if level4_button.is_clicked(event):
                 current_map = "fourelements.txt"
+                random_map = False
+                return level_selection()
             if random_button.is_clicked(event):
                 random_map = True
                 seed = random.randint(0, 999999)
+                return level_selection()
             if back_button.is_clicked(event):
                 return
 
@@ -1075,9 +1114,7 @@ def gameover(camera, map_renderer, robot_renderer, robots, player, score=-1, kil
                 highestkills = kills
             draw_text(screen, f"Highscore: {highscore}s", 0, 330, 70, center=True)
             draw_text(screen, f"Score: {score}s", 0, 400, 70, center=True)
-            draw_text(
-                screen, f"Highest Kills: {highestkills}", 0, 470, 70, center=True
-            )
+            draw_text(screen, f"Highest Kills: {highestkills}", 0, 470, 70, center=True)
             draw_text(screen, f"Kills: {kills}", 0, 540, 70, center=True)
 
         pygame.display.flip()

--- a/src/robot.py
+++ b/src/robot.py
@@ -304,6 +304,8 @@ class Robot:
         if newRect.collidelist(walls) == -1:
             self.x = xnew
             self.y = ynew
+            if len(robots) < 2:
+                return
             (dist, robot) = self.robot_dist(robots)[0]
             if dist <= 0:
                 self.x -= x
@@ -441,7 +443,7 @@ class Robot:
             config.TILE_SIZE * (config.COLUMNS - 2),
         )
         min_dist = max_dist / (len(robots) + 1)
-        if self.robot_dist(robots)[0][0] > min_dist:
+        if len(robots) < 2 or self.robot_dist(robots)[0][0] > min_dist:
             # Check for tiles to avoid walls, lava and bush
             touched_textures = self.touched_textures(game_map)
             if (
@@ -516,10 +518,11 @@ class Robot:
                 if hitbox.collidelist(walls) == -1:
                     self.x = xnew
                     self.y = ynew
-                    (dist, robot) = self.robot_dist(robots)[0]
-                    if dist <= 0:
-                        self.x -= x
-                        self.robot_collision(robot, robots, walls)
+                    if len(robots) > 1:
+                        (dist, robot) = self.robot_dist(robots)[0]
+                        if dist <= 0:
+                            self.x -= x
+                            self.robot_collision(robot, robots, walls)
                 else:
                     # check and move if only in y direction is no wall
                     xnew = self.x
@@ -528,10 +531,11 @@ class Robot:
                     if hitbox.collidelist(walls) == -1:
                         self.x = xnew
                         self.y = ynew
-                        (dist, robot) = self.robot_dist(robots)[0]
-                        if dist <= 0:
-                            self.y -= y
-                            self.robot_collision(robot, robots, walls)
+                        if len(robots) > 1:
+                            (dist, robot) = self.robot_dist(robots)[0]
+                            if dist <= 0:
+                                self.y -= y
+                                self.robot_collision(robot, robots, walls)
 
     def shoot(
         self,


### PR DESCRIPTION
- fixed mistake in dist to robots in robot.py
- game over screen with scores and kills looked wrong
- avoid having to wait in survival1 for new opponent
- adjusted buttons to show which is selected


There sometimes was a mistake in survival 1 in the function to get the **distance to other robot, since usually when only 1 robot is in the game the game changes to victory or game-over.
I added a condition when the function is called to exclude running the function if there is only 1 robot.

Since the addition of the kills, the highscore screen in game-over looks a bit weird,
which I tried to resolve.

Also in survival1, sometimes you had to wait quite a bit for the next robot to appear, so  a new one appears if there is no other.

As we once talked about I adjusted the buttons to show which difficulty/class/map/... is selected.